### PR TITLE
meta-sgl-core: add zero-conf networking to image

### DIFF
--- a/meta-sgl-core/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-sgl-core/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://ssh.service \
+"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/avahi/services
+    install -m 0644 ${WORKDIR}/ssh.service ${D}${sysconfdir}/avahi/services/
+}

--- a/meta-sgl-core/recipes-connectivity/avahi/files/ssh.service
+++ b/meta-sgl-core/recipes-connectivity/avahi/files/ssh.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h SSH Server</name>
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+  </service>
+</service-group>

--- a/meta-sgl-core/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-sgl-core/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,9 @@
+IMAGE_INSTALL:append = " \
+    avahi-daemon \
+    avahi-utils \
+    libnss-mdns \
+"
+
+IMAGE_FEATURES:append = " \
+   ssh-server-openssh \
+"


### PR DESCRIPTION
# Justification

Provide infrastructure for user to interact with device over SSH out-of-the-box with an easy-to-remember mDNS-resovable name. This takes a lot of the friction out of getting started with target-hardware, since a user can simply ssh into the machine using its hostname.

# Implementation

Add OpenSSH's implementation of an SSH server.

Add nss-mdns + avahi to create and publish name over mDNS. Name is `<hostname>.local` and each device will advertise SSH as a service, so any client which also implements DNS-SD can discover that functionality.

# Testing Done

On-target, use `avahi-browse` to observe device publishing SSH service on IPv6, IPv4, and lo. This tells us that the avahi daemon and avahi utilities are working:

```
root@beaglev-fire:~# avahi-browse -at | grep beagle
+   eth0 IPv6 beaglev-fire SSH Server                       _ssh._tcp            local
+   eth0 IPv4 beaglev-fire SSH Server                       _ssh._tcp            local
+     lo IPv4 beaglev-fire SSH Server                       _ssh._tcp            local
```

On-target, ping using the `<hostname>.local` semantics, showing that nss-mdns is working (at least, over local interface):

```
root@beaglev-fire:~# ping beaglev-fire.local
PING beaglev-fire.local (127.0.0.1): 56 data bytes
64 bytes from 127.0.0.1: seq=0 ttl=64 time=0.307 ms
64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.148 ms
64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.174 ms
64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.142 ms
64 bytes from 127.0.0.1: seq=4 ttl=64 time=0.124 ms
```

Off-target (network connected, same subnet), use `avahi-browse` to see if we can see target advertise its SSH "service":

```
$ avahi-browse -at | grep beagle
+   eno1 IPv6 beaglev-fire SSH Server                       SSH Remote Terminal  local
+   eno1 IPv4 beaglev-fire SSH Server                       SSH Remote Terminal  local
```

Off-target (network connected, same subnet), SSH into target:

```
$ ssh root@beaglev-fire.local
This is version v2025.03 of the Polarfire SoC Yocto BSP.

Updated images and documentation are available at:
        https://github.com/polarfire-soc/

root@beaglev-fire:~#
root@beaglev-fire:~#
root@beaglev-fire:~# exit
Connection to beaglev-fire.local closed.
```