### PR TITLE
kas: Use the upstream meta-sgl git repository

### DIFF
--- a/kas/sgl/sgl.yml
+++ b/kas/sgl/sgl.yml
@@ -5,7 +5,7 @@ distro: "sgl"
 
 repos:
   sgl:
-    url: "https://github.com/robwoolley/meta-sgl.git"
+    url: "https://github.com/elisa-tech/meta-sgl.git"
     path: "layers/meta-sgl"
     branch: "main"
     layers:


### PR DESCRIPTION
We should have kas pull from elisa-tech/meta-sgl not from robwoolley/meta-sgl.