### PR TITLE
meta-sgl-core: add zeroconf networking as optional image feature

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -24,8 +24,8 @@ export default defineConfig({
         text: 'Guides',
         items: [
           { text: 'Building', link: '/building' },
+          { text: 'Development Setup', link: '/development' },
           { text: 'Contribute', link: '/contribute' },
-
         ]
       }
     ],

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,100 @@
+# Development Setup
+
+This guide covers optional image features useful for development and testing with Space Grade Linux.
+
+## Optional Image Features
+
+SGL supports optional image features that can be enabled at build time using the `OPTIONAL_FEATURES` environment variable. Multiple features can be enabled by separating them with spaces.
+
+```bash
+OPTIONAL_FEATURES="feature1 feature2" kas build kas/sgl-scarthgap-qemuarm64.yml
+```
+
+## Enabling SSH Access
+
+To enable SSH server access on your image, add the `ssh-server-openssh` feature:
+
+```bash
+OPTIONAL_FEATURES="ssh-server-openssh" kas build kas/sgl-scarthgap-qemuarm64.yml
+```
+
+This will include the OpenSSH server in your image, allowing you to connect remotely.
+
+::: info
+The default login is `root` without a password.
+:::
+
+## Zeroconf Networking (mDNS/DNS-SD)
+
+Zeroconf networking allows your device to be discoverable on the local network using a human-readable hostname (e.g., `hostname.local`) without requiring DNS configuration.
+
+### Enabling Zeroconf
+
+To enable zeroconf networking, add the `zeroconf-networking` feature:
+
+```bash
+OPTIONAL_FEATURES="zeroconf-networking" kas build kas/sgl-scarthgap-qemuarm64.yml
+```
+
+This installs:
+- **avahi-daemon**: mDNS/DNS-SD service daemon
+- **avahi-utils**: Command-line utilities for browsing services
+- **libnss-mdns**: NSS plugin for mDNS hostname resolution
+
+### Development Build with SSH and Zeroconf
+
+For a full development setup with both SSH and zeroconf, combine the features:
+
+```bash
+OPTIONAL_FEATURES="ssh-server-openssh zeroconf-networking" kas build kas/sgl-scarthgap-qemuarm64.yml
+```
+
+### Connecting to Your Device
+
+Once your device is running with zeroconf enabled, you can connect using the hostname:
+
+```bash
+ssh root@<hostname>.local
+```
+
+For example, if your device's hostname is `qemuriscv64`:
+
+```bash
+ssh root@qemuriscv64.local
+```
+
+### Discovering Devices on the Network
+
+From another machine with Avahi installed, you can discover SGL devices advertising SSH:
+
+```bash
+avahi-browse -at | grep SSH
+```
+
+Example output:
+```
++   eth0 IPv6 mydevice SSH Server    _ssh._tcp    local
++   eth0 IPv4 mydevice SSH Server    _ssh._tcp    local
+```
+
+### Verifying Zeroconf on the Device
+
+On the target device, verify that Avahi is running and advertising services:
+
+```bash
+avahi-browse -at
+```
+
+You can also test mDNS resolution locally:
+
+```bash
+ping $(hostname).local
+```
+
+## Feature Reference
+
+| Feature | Description |
+|---------|-------------|
+| `ssh-server-openssh` | OpenSSH server for remote access |
+| `ssh-server-dropbear` | Dropbear SSH server (lightweight alternative) |
+| `zeroconf-networking` | mDNS/DNS-SD support via Avahi |

--- a/kas/sgl/sgl.yml
+++ b/kas/sgl/sgl.yml
@@ -13,3 +13,12 @@ repos:
 
 target:
   - core-image-minimal
+
+local_conf_header:
+  sgl_image_common: |
+    INHERIT += "sgl-image-common"
+  optional_features: |
+    IMAGE_FEATURES:append = " ${OPTIONAL_FEATURES}"
+
+env:
+  OPTIONAL_FEATURES: ""

--- a/meta-sgl-core/classes/sgl-image-common.bbclass
+++ b/meta-sgl-core/classes/sgl-image-common.bbclass
@@ -1,0 +1,5 @@
+# This class defines common image features or other
+# configurations to be shared by many images
+# in meta-sgl
+
+FEATURE_PACKAGES_zeroconf-networking = "avahi-daemon avahi-utils libnss-mdns"

--- a/meta-sgl-core/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-sgl-core/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+   ${@bb.utils.contains_any('IMAGE_FEATURES', 'ssh-server-dropbear ssh-server-openssh', 'file://ssh.service', '', d)} \
+"
+
+do_install:append() {
+    if ${@bb.utils.contains_any('IMAGE_FEATURES', 'ssh-server-dropbear ssh-server-openssh', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/avahi/services
+        install -m 0644 ${WORKDIR}/ssh.service ${D}${sysconfdir}/avahi/services/
+    fi
+}

--- a/meta-sgl-core/recipes-connectivity/avahi/files/ssh.service
+++ b/meta-sgl-core/recipes-connectivity/avahi/files/ssh.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h SSH Server</name>
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+  </service>
+</service-group>


### PR DESCRIPTION
Adds the zeroconf networking functionality from #8 by @dwells35.

Created as a new PR because the original included CI changes and `sgl-image-minimal` that are now redundant with main. This PR extracts only the zeroconf feature.

## Usage

```bash
OPTIONAL_FEATURES="ssh-server-openssh zeroconf-networking" kas build kas/sgl-scarthgap-qemuarm64.yml
```

See `docs/development.md` for details.

Closes #8