### PR TITLE
Add kas QEMU + Space ROS support for riscv and arm64

### DIFF
--- a/.github/workflows/test_build_qemu_arm64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_arm64_spaceros.yml
@@ -1,0 +1,73 @@
+name: Build SGL QEMU ARM64 Space ROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "Setup Env & Build"
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
+    env:
+      KAS_WORK_DIR: "${{ github.workspace }}/kas-build"
+      HARDWARE_ARCH: qemuarm64
+
+    steps:
+      - uses: runs-on/action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: layers/meta-sgl
+
+      - name: Set up cache for Yocto downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.KAS_WORK_DIR }}/build/downloads
+          key: ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yocto-downloads-
+
+      - name: Set up cache for sstate
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.KAS_WORK_DIR }}/build/sstate-cache
+          key: ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yocto-sstate-
+
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gawk wget git-core diffstat unzip texinfo \
+            build-essential chrpath socat libsdl1.2-dev xterm \
+            python3-pexpect python3-pip
+
+      - name: Re-enable user namespaces and disable AppArmor restriction
+        run: |
+          # Re-enable unprivileged user namespaces
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          # Disable AppArmor restriction for user namespaces
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install kas and BitBake
+        run: |
+          python -m pip install --upgrade pip
+          pip install kas
+
+      - name: Build SGL
+        run: |
+          # Determine available cores for parallel build
+          CORES=$(nproc)
+          export BB_NUMBER_THREADS=$CORES
+          export PARALLEL_MAKE="-j$CORES"
+          mkdir -p "$KAS_WORK_DIR"
+          kas build layers/meta-sgl/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml

--- a/.github/workflows/test_build_qemu_riscv64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_riscv64_spaceros.yml
@@ -1,0 +1,73 @@
+name: Build SGL QEMU RISCV Space ROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "Setup Env & Build"
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
+    env:
+      KAS_WORK_DIR: "${{ github.workspace }}/kas-build"
+      HARDWARE_ARCH: qemuriscv
+
+    steps:
+      - uses: runs-on/action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: layers/meta-sgl
+
+      - name: Set up cache for Yocto downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.KAS_WORK_DIR }}/build/downloads
+          key: ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yocto-downloads-
+
+      - name: Set up cache for sstate
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.KAS_WORK_DIR }}/build/sstate-cache
+          key: ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yocto-sstate-
+
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gawk wget git-core diffstat unzip texinfo \
+            build-essential chrpath socat libsdl1.2-dev xterm \
+            python3-pexpect python3-pip
+
+      - name: Re-enable user namespaces and disable AppArmor restriction
+        run: |
+          # Re-enable unprivileged user namespaces
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          # Disable AppArmor restriction for user namespaces
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install kas and BitBake
+        run: |
+          python -m pip install --upgrade pip
+          pip install kas
+
+      - name: Build SGL
+        run: |
+          # Determine available cores for parallel build
+          CORES=$(nproc)
+          export BB_NUMBER_THREADS=$CORES
+          export PARALLEL_MAKE="-j$CORES"
+          mkdir -p "$KAS_WORK_DIR"
+          kas build layers/meta-sgl/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuarm64.yml
+    - kas/spaceros/jazzy-2025.10.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuriscv64.yml
+    - kas/spaceros/jazzy-2025.10.yml


### PR DESCRIPTION
Pull request adds QEMU + Space ROS kas configuration manifests for QEMU machines: riscv and arm64. This partly solves issue #27.