### PR TITLE
ci: refactor CI into reusable workflow and add QEMU SpaceROS + x86-64 targets

### DIFF
--- a/.github/workflows/build-sgl.yml
+++ b/.github/workflows/build-sgl.yml
@@ -1,0 +1,107 @@
+name: Build SGL
+
+on:
+  workflow_call:
+    inputs:
+      kas_config:
+        description: 'KAS configuration file to build (relative to kas/)'
+        required: true
+        type: string
+      hardware_arch:
+        description: 'Hardware architecture identifier for caching'
+        required: true
+        type: string
+      runner_arch:
+        description: 'Runner architecture: arm64 or x64'
+        type: string
+        default: 'arm64'
+      runner_size:
+        description: 'Runner size: default (32-cpu) or xlarge (64-cpu)'
+        type: string
+        default: 'default'
+      build_profile:
+        description: 'Build profile for cache isolation (e.g. sgl, spaceros)'
+        type: string
+        default: 'sgl'
+
+env:
+  META_SGL_DIR: kas-build/layers/meta-sgl
+  APT_CACHE_DIR: /home/runner/.cache/apt
+
+jobs:
+  build:
+    runs-on: >-
+      runs-on=${{ github.run_id }}/runner=${{ inputs.runner_size }}-${{ inputs.runner_arch }}
+    env:
+      KAS_WORK_DIR: "${{ github.workspace }}/kas-build"
+      HARDWARE_ARCH: ${{ inputs.hardware_arch }}
+
+    steps:
+      - uses: runs-on/action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: kas-build/layers/meta-sgl
+
+      - name: Set up cache for Yocto downloads
+        uses: runs-on/cache@v4
+        with:
+          path: ${{ env.KAS_WORK_DIR }}/build/downloads
+          key: ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-${{ inputs.build_profile }}-${{ hashFiles('kas-build/layers/meta-sgl/kas/**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-${{ inputs.build_profile }}-
+            ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-
+
+      - name: Set up cache for sstate
+        uses: runs-on/cache@v4
+        with:
+          path: ${{ env.KAS_WORK_DIR }}/build/sstate-cache
+          key: ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-${{ inputs.build_profile }}-${{ hashFiles('kas-build/layers/meta-sgl/kas/**/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-${{ inputs.build_profile }}-
+            ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-
+
+      - name: Cache apt packages
+        uses: runs-on/cache@v4
+        with:
+          path: ${{ env.APT_CACHE_DIR }}
+          key: ${{ runner.os }}-apt-${{ runner.arch }}-yocto-host-deps
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update
+          # Copy cached debs into apt cache if available
+          if [ -d "$APT_CACHE_DIR" ] && [ "$(ls -A "$APT_CACHE_DIR")" ]; then
+            sudo cp "$APT_CACHE_DIR"/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+          fi
+          sudo apt-get install -y gawk wget git-core diffstat unzip texinfo \
+            build-essential chrpath socat libsdl1.2-dev xterm \
+            python3-pexpect python3-pip
+          # Save debs for next run
+          mkdir -p "$APT_CACHE_DIR"
+          cp /var/cache/apt/archives/*.deb "$APT_CACHE_DIR"/ 2>/dev/null || true
+
+      - name: Re-enable user namespaces and disable AppArmor restriction
+        run: |
+          # Re-enable unprivileged user namespaces
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          # Disable AppArmor restriction for user namespaces
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install kas and BitBake
+        run: |
+          python -m pip install --upgrade pip
+          pip install kas
+
+      - name: Build SGL
+        run: |
+          # Determine available cores for parallel build
+          CORES=$(nproc)
+          export BB_NUMBER_THREADS=$CORES
+          export PARALLEL_MAKE="-j$CORES"
+          mkdir -p "$KAS_WORK_DIR"
+          kas build $KAS_WORK_DIR/layers/meta-sgl/kas/${{ inputs.kas_config }}:$KAS_WORK_DIR/layers/meta-sgl/kas/ci/local-checkout.yml

--- a/.github/workflows/test_build_beaglevfire_spaceros.yml
+++ b/.github/workflows/test_build_beaglevfire_spaceros.yml
@@ -1,4 +1,4 @@
-name: Build SGL BeagleV-Fire Space ROS
+name: BeagleV-Fire + SpaceROS
 
 on:
   push:
@@ -10,64 +10,8 @@ on:
 
 jobs:
   build:
-    name: "Setup Env & Build"
-    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache/family=c7gd+m7gd
-    env:
-      KAS_WORK_DIR: "${{ github.workspace }}/kas-build"
-      HARDWARE_ARCH: beaglev-fire
-
-    steps:
-      - uses: runs-on/action@v2
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          path: layers/meta-sgl
-
-      - name: Set up cache for Yocto downloads
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.KAS_WORK_DIR }}/build/downloads
-          key: ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-yocto-downloads-
-
-      - name: Set up cache for sstate
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.KAS_WORK_DIR }}/build/sstate-cache
-          key: ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-yocto-sstate-
-
-      - name: Install host dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gawk wget git-core diffstat unzip texinfo \
-            build-essential chrpath socat libsdl1.2-dev xterm \
-            python3-pexpect python3-pip
-
-      - name: Re-enable user namespaces and disable AppArmor restriction
-        run: |
-          # Re-enable unprivileged user namespaces
-          sudo sysctl -w kernel.unprivileged_userns_clone=1
-          # Disable AppArmor restriction for user namespaces
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install kas and BitBake
-        run: |
-          python -m pip install --upgrade pip
-          pip install kas
-
-      - name: Build SGL
-        run: |
-          # Determine available cores for parallel build
-          CORES=$(nproc)
-          export BB_NUMBER_THREADS=$CORES
-          export PARALLEL_MAKE="-j$CORES"
-          mkdir -p "$KAS_WORK_DIR"
-          kas build layers/meta-sgl/kas/sgl-scarthgap-spaceros-jazzy-2025.10-beaglev-fire.yml
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-beaglev-fire.yml
+      hardware_arch: beaglev-fire
+      build_profile: spaceros

--- a/.github/workflows/test_build_qemu_arm64.yml
+++ b/.github/workflows/test_build_qemu_arm64.yml
@@ -1,4 +1,4 @@
-name: Build SGL QEMU ARM64
+name: QEMU ARM64
 
 on:
   push:
@@ -10,64 +10,7 @@ on:
 
 jobs:
   build:
-    name: "Setup Env & Build"
-    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-arm64/image=ubuntu24-full-arm64/extras=s3-cache
-    env:
-      KAS_WORK_DIR: "${{ github.workspace }}/kas-build"
-      HARDWARE_ARCH: qemuarm64
-
-    steps:
-      - uses: runs-on/action@v2
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          path: layers/meta-sgl
-
-      - name: Set up cache for Yocto downloads
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.KAS_WORK_DIR }}/build/downloads
-          key: ${{ runner.os }}-yocto-downloads-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-yocto-downloads-
-
-      - name: Set up cache for sstate
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.KAS_WORK_DIR }}/build/sstate-cache
-          key: ${{ runner.os }}-yocto-sstate-${{ env.HARDWARE_ARCH }}-${{ hashFiles('kas/common.yml', 'kas/sgl/sgl.yml', 'kas/yocto/**/*.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-yocto-sstate-
-
-      - name: Install host dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gawk wget git-core diffstat unzip texinfo \
-            build-essential chrpath socat libsdl1.2-dev xterm \
-            python3-pexpect python3-pip
-
-      - name: Re-enable user namespaces and disable AppArmor restriction
-        run: |
-          # Re-enable unprivileged user namespaces
-          sudo sysctl -w kernel.unprivileged_userns_clone=1
-          # Disable AppArmor restriction for user namespaces
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install kas and BitBake
-        run: |
-          python -m pip install --upgrade pip
-          pip install kas
-
-      - name: Build SGL
-        run: |
-          # Determine available cores for parallel build
-          CORES=$(nproc)
-          export BB_NUMBER_THREADS=$CORES
-          export PARALLEL_MAKE="-j$CORES"
-          mkdir -p "$KAS_WORK_DIR"
-          kas build layers/meta-sgl/kas/sgl-scarthgap-qemuarm64.yml
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-qemuarm64.yml
+      hardware_arch: qemuarm64

--- a/.github/workflows/test_build_qemu_arm64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_arm64_spaceros.yml
@@ -1,0 +1,17 @@
+name: QEMU ARM64 + SpaceROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+      hardware_arch: qemuarm64
+      build_profile: spaceros

--- a/.github/workflows/test_build_qemu_riscv64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_riscv64_spaceros.yml
@@ -1,0 +1,17 @@
+name: QEMU RISCV64 + SpaceROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
+      hardware_arch: qemuriscv64
+      build_profile: spaceros

--- a/.github/workflows/test_build_qemu_x86-64.yml
+++ b/.github/workflows/test_build_qemu_x86-64.yml
@@ -1,0 +1,17 @@
+name: QEMU x86-64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-qemux86-64.yml
+      hardware_arch: qemux86-64
+      runner_arch: x64

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -9,6 +9,69 @@ To sign off your commits, use the `-s` flag:
 git commit -sv
 ```
 
+## CI workflows
+
+All build workflows use a shared reusable workflow (`.github/workflows/build-sgl.yml`) that handles caching, host setup, and the kas build. Each target has a thin caller workflow that passes the kas config, hardware architecture, and build profile.
+
+Runners are configured in `.github/runs-on.yml` using [RunsOn](https://runs-on.com) named profiles. All runners use on-demand EC2 instances with local NVMe storage.
+
+### Adding a new build target
+
+1. Create a kas configuration file in `kas/`:
+
+```yaml
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuarm64.yml
+    - kas/spaceros/jazzy-2025.10.yml
+```
+
+2. Create a workflow caller in `.github/workflows/`:
+
+```yaml
+name: QEMU ARM64 + SpaceROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+      hardware_arch: qemuarm64
+      build_profile: spaceros
+```
+
+Available inputs for `build-sgl.yml`:
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `kas_config` | yes | — | KAS config file relative to `kas/` |
+| `hardware_arch` | yes | — | Architecture identifier, used for cache keys |
+| `runner_arch` | no | `arm64` | Runner architecture: `arm64` or `x64` |
+| `runner_size` | no | `default` | Runner size: `default` (32-cpu) or `xlarge` (64-cpu) |
+| `build_profile` | no | `sgl` | Cache isolation key (e.g. `sgl`, `spaceros`) |
+
+Set `runner_arch: x64` for native x86-64 builds. Set `build_profile: spaceros` for SpaceROS targets to isolate their sstate cache from base SGL builds.
+
+### Debugging a failing workflow
+
+Check the runner details in the "Set up job" step — it shows the instance type, CPU count, disk space, and whether the instance is on-demand or spot.
+
+Common failure modes:
+
+- **"No space left on device"** — The runner ran out of disk. Ensure the runner config in `.github/runs-on.yml` uses instance families with local NVMe (the `d` suffix, e.g. `c7gd`, `c6id`).
+- **"The runner has received a shutdown signal"** — The EC2 instance was terminated. If using spot instances (`spot: true`), switch to on-demand (`spot: false`). If already on-demand, this may be a transient EC2 issue — re-run the job.
+- **"No matching instance pools"** — The requested instance family/size doesn't exist in the region. Check that the families in `.github/runs-on.yml` are available in `us-east-2`.
+- **Cache miss on a warm build** — Cache keys include `hardware_arch`, `build_profile`, and a hash of all kas configs. A change to any kas file rotates all caches. S3 cache expires after 30 days.
+
 ## Contribute to documentation
 
 The SGL website and documentation is written in Markdown and compiled into a

--- a/kas/ci/local-checkout.yml
+++ b/kas/ci/local-checkout.yml
@@ -1,0 +1,17 @@
+# Use this overlay when building from a local checkout of meta-sgl.
+# Setting url to null and providing path tells kas to use the local directory
+# instead of cloning from the remote repository.
+#
+# Usage:
+#   kas build kas/sgl-scarthgap-qemuarm64.yml:kas/ci/local-checkout.yml
+#
+# See: https://kas.readthedocs.io/en/latest/userguide/project-configuration.html
+
+header:
+  version: 14
+
+repos:
+  sgl:
+    url:
+    branch:
+    path: layers/meta-sgl

--- a/kas/sgl-scarthgap-qemux86-64.yml
+++ b/kas/sgl-scarthgap-qemux86-64.yml
@@ -1,0 +1,8 @@
+header:
+  version: 14
+  includes:
+    - kas/yocto/scarthgap.yml
+    - kas/machine/qemux86-64.yml
+    - kas/common.yml
+    - kas/sgl/sgl.yml
+    - kas/sgl/clang.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuarm64.yml
+    - kas/spaceros/jazzy-2025.10.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuriscv64.yml
+    - kas/spaceros/jazzy-2025.10.yml


### PR DESCRIPTION
Consolidates the duplicated CI build logic into a single reusable workflow and adds QEMU SpaceROS and x86-64 build targets. Each target workflow is now ~17 lines instead of ~73, making it trivial to add new build configurations. Supersedes #32 and #33, based on work by @alenik22.

- Extract build steps into `build-sgl.yml` reusable workflow with inputs for kas config, hardware arch, runner arch (`arm64`/`x64`), and runner size (`large_runner` boolean)
- Callers reference named RunsOn runner profiles defined in `.github/runs-on.yml`
- Switch from `actions/cache` to `runs-on/cache` (S3-backed, same-region, no size limits)
- Simplify `hashFiles` to `kas/**/*.yml` so cache rotates on any kas config change
- Add `kas/ci/local-checkout.yml` overlay so CI uses the checked-out repo instead of cloning
- Add QEMU ARM64 Space ROS, QEMU RISCV64 Space ROS, and QEMU x86-64 workflows and kas configs
- Clean up workflow names for readability (e.g. "QEMU ARM64" instead of "Build SGL QEMU ARM64")
- Bump `actions/checkout` to v4 and `actions/setup-python` to v5