### PR TITLE
kas: Add Space ROS Jazzy 2026.01

### DIFF
--- a/.github/workflows/test_build_beaglevfire_spaceros.yml
+++ b/.github/workflows/test_build_beaglevfire_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-beaglev-fire.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.01-beaglev-fire.yml
       hardware_arch: beaglev-fire
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_arm64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_arm64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.01-qemuarm64.yml
       hardware_arch: qemuarm64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_riscv64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_riscv64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.01-qemuriscv64.yml
       hardware_arch: qemuriscv64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_x86-64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_x86-64_spaceros.yml
@@ -1,0 +1,17 @@
+name: QEMU x86-64 + SpaceROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.01-qemux86-64.yml
+      hardware_arch: qemux86-64
+      build_profile: spaceros

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.01-beaglev-fire.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.01-beaglev-fire.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-beaglev-fire.yml
+    - kas/spaceros/jazzy-2026.01.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.01-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.01-qemuarm64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuarm64.yml
+    - kas/spaceros/jazzy-2026.01.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.01-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.01-qemuriscv64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuriscv64.yml
+    - kas/spaceros/jazzy-2026.01.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.01-qemux86-64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.01-qemux86-64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemux86-64.yml
+    - kas/spaceros/jazzy-2026.01.yml

--- a/kas/spaceros/jazzy-2026.01.yml
+++ b/kas/spaceros/jazzy-2026.01.yml
@@ -1,0 +1,16 @@
+header:
+  version: 14
+
+repos:
+  spaceros:
+    url: "https://github.com/ros/meta-ros.git"
+    path: "layers/meta-ros"
+    layers:
+      meta-ros-common:
+      meta-ros2:
+      meta-spaceros:
+      meta-spaceros-jazzy:
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/spaceros/jazzy-2026.01.yml
+++ b/kas/spaceros/jazzy-2026.01.yml
@@ -5,6 +5,7 @@ repos:
   spaceros:
     url: "https://github.com/ros/meta-ros.git"
     path: "layers/meta-ros"
+    commit: "43b1db881597bb37740b663c204b33108cfe364c"
     layers:
       meta-ros-common:
       meta-ros2:

--- a/kas/yocto/kirkstone.yml
+++ b/kas/yocto/kirkstone.yml
@@ -5,11 +5,11 @@ defaults:
   repos:
     branch: "kirkstone"
 
-# https://downloads.yoctoproject.org/releases/yocto/yocto-4.0.32/RELEASENOTES
+# https://downloads.yoctoproject.org/releases/yocto/yocto-4.0.35/RELEASENOTES
 repos:
   openembedded-core:
     url: "https://github.com/openembedded/openembedded-core.git"
-    commit: "2ed3f8b938579dbbb804e04c45a968cc57761db7"
+    commit: "51259c7e933a2ac8ebc01604d6e65607b76b7b56"
     path: "layers/openembedded-core"
     layers:
       meta:
@@ -17,14 +17,14 @@ repos:
   bitbake:
     url: "https://github.com/openembedded/bitbake.git"
     branch: "2.0"
-    commit: "8e2d1f8de055549b2101614d85454fcd1d0f94b2"
+    commit: "7fd0197fd5fedd23cc885b5e7e816d86a392fdf9"
     path: "layers/bitbake"
     layers:
       bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    commit: "7d4507f226bd2af939d4482fb14a809867ece939"
+    commit: "9d8ef26a9693e2c70ae34abe1a753873d42ec588"
     path: "layers/meta-openembedded"
     layers:
       meta-filesystems:

--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -32,3 +32,8 @@ repos:
       meta-python:
       meta-webserver:
       meta-xfce:
+
+  clang-revival:
+    branch: "main"
+    layers:
+      meta-clang-revival: "disabled"

--- a/kas/yocto/scarthgap.yml
+++ b/kas/yocto/scarthgap.yml
@@ -7,11 +7,11 @@ defaults:
   repos:
     branch: "scarthgap"
 
-# https://downloads.yoctoproject.org/releases/yocto/yocto-5.0.14/RELEASENOTES
+# https://downloads.yoctoproject.org/releases/yocto/yocto-5.0.17/RELEASENOTES
 repos:
   openembedded-core:
     url: "https://github.com/openembedded/openembedded-core.git"
-    commit: "471adaa5f77fa3b974eab60a2ded48e360042828"
+    commit: "52380df998b3a8fe6a091f8547434a3231320a8e"
     path: "layers/openembedded-core"
     layers:
       meta:
@@ -19,14 +19,14 @@ repos:
   bitbake:
     url: "https://github.com/openembedded/bitbake.git"
     branch: "2.8"
-    commit: "8dcf084522b9c66a6639b5f117f554fde9b6b45a"
+    commit: "d3b4c352dd33fca90cd31649eda054b884478739"
     path: "layers/bitbake"
     layers:
       bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    commit: "2b26d30fc7f478f5735d514f0c1bc28f6a4148b6"
+    commit: "5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e"
     path: "layers/meta-openembedded"
     layers:
       meta-filesystems:

--- a/kas/yocto/wrynose.yml
+++ b/kas/yocto/wrynose.yml
@@ -1,0 +1,51 @@
+header:
+  version: 14
+
+defaults:
+  repos:
+    branch: "wrynose"
+
+# https://downloads.yoctoproject.org/releases/yocto/yocto-6.0/RELEASENOTES
+repos:
+  openembedded-core:
+    url: "https://github.com/openembedded/openembedded-core.git"
+    commit: "42fa856a00ac16b2a7a83d7ecfa60a5be192b16c"
+    path: "layers/openembedded-core"
+    layers:
+      meta:
+
+  bitbake:
+    url: "https://github.com/openembedded/bitbake.git"
+    branch: "2.18"
+    commit: "33581c84f3a85008239acbd940501a35de48dc91"
+    path: "layers/bitbake"
+    layers:
+      bitbake: "disabled"
+
+  meta-yocto:
+    url: "https://git.yoctoproject.org/meta-yocto"
+    commit: "904846ae078ee20de073040ebb77c86e19250f56"
+    path: "layers/meta-yocto"
+    layers:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: "https://github.com/openembedded/meta-openembedded.git"
+    commit: "420222862f5a6d95023b8f5f3b7e1808b2264ef9"
+    path: "layers/meta-openembedded"
+    layers:
+      meta-filesystems:
+      meta-gnome:
+      meta-initramfs:
+      meta-multimedia:
+      meta-networking:
+      meta-oe:
+      meta-perl:
+      meta-python:
+      meta-webserver:
+      meta-xfce:
+
+local_conf_header:
+  distro: |
+    ERROR_QA:remove = "license-exists"


### PR DESCRIPTION
This commit adds the kas configuration files to build Space ROS Jazzy 2026.01 from meta-ros.

The changes in meta-ros add recipes for Space ROS including core, moveit2, nav2, and demos.