### PR TITLE
docs: relicense from CC-BY-SA-4.0 to CC-BY-4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ license it under the terms described below.
   files) is contributed under the [MIT License](LICENSE.MIT).
 - **Documentation** (files under `docs/`, READMEs, and similar prose) is
   currently contributed under
-  [Creative Commons Attribution-ShareAlike 4.0](LICENSE.CC-BY-SA-4.0), as
+  [Creative Commons Attribution 4.0](LICENSE.CC-BY-4.0), as
   stated in [`LICENSE`](LICENSE).
 
 See [`LICENSE`](LICENSE) for the authoritative summary.

--- a/LICENSE
+++ b/LICENSE
@@ -9,9 +9,9 @@ otherwise stated.
 See LICENSE.MIT for details of the MIT license.
 
 It is preferred that any documentation in this repo be available under
-the CC-BY-SA-4 license.
+the CC-BY-4.0 license.
 
-See LICENSE.CC-BY-SA-4.0 for details of that license.
+See LICENSE.CC-BY-4.0 for details of that license.
 
 License information for any other files is either explicitly stated
 or defaults to MIT.

--- a/LICENSE.CC-BY-4.0
+++ b/LICENSE.CC-BY-4.0
@@ -1,15 +1,13 @@
-Creative Commons Attribution-ShareAlike 4.0 International Public
-License
+Creative Commons Attribution 4.0 International Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree
 to be bound by the terms and conditions of this Creative Commons
-Attribution-ShareAlike 4.0 International Public License ("Public
-License"). To the extent this Public License may be interpreted as a
-contract, You are granted the Licensed Rights in consideration of Your
-acceptance of these terms and conditions, and the Licensor grants You
-such rights in consideration of benefits the Licensor receives from
-making the Licensed Material available under these terms and
-conditions.
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
 
 
 Section 1 -- Definitions.
@@ -28,11 +26,7 @@ Section 1 -- Definitions.
      and Similar Rights in Your contributions to Adapted Material in
      accordance with the terms and conditions of this Public License.
 
-  c. BY-SA Compatible License means a license listed at
-     creativecommons.org/compatiblelicenses, approved by Creative
-     Commons as essentially the equivalent of this Public License.
-
-  d. Copyright and Similar Rights means copyright and/or similar rights
+  c. Copyright and Similar Rights means copyright and/or similar rights
      closely related to copyright including, without limitation,
      performance, broadcast, sound recording, and Sui Generis Database
      Rights, without regard to how the rights are labeled or
@@ -40,33 +34,29 @@ Section 1 -- Definitions.
      specified in Section 2(b)(1)-(2) are not Copyright and Similar
      Rights.
 
-  e. Effective Technological Measures means those measures that, in the
+  d. Effective Technological Measures means those measures that, in the
      absence of proper authority, may not be circumvented under laws
      fulfilling obligations under Article 11 of the WIPO Copyright
      Treaty adopted on December 20, 1996, and/or similar international
      agreements.
 
-  f. Exceptions and Limitations means fair use, fair dealing, and/or
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
      any other exception or limitation to Copyright and Similar Rights
      that applies to Your use of the Licensed Material.
 
-  g. License Elements means the license attributes listed in the name
-     of a Creative Commons Public License. The License Elements of this
-     Public License are Attribution and ShareAlike.
-
-  h. Licensed Material means the artistic or literary work, database,
+  f. Licensed Material means the artistic or literary work, database,
      or other material to which the Licensor applied this Public
      License.
 
-  i. Licensed Rights means the rights granted to You subject to the
+  g. Licensed Rights means the rights granted to You subject to the
      terms and conditions of this Public License, which are limited to
      all Copyright and Similar Rights that apply to Your use of the
      Licensed Material and that the Licensor has authority to license.
 
-  j. Licensor means the individual(s) or entity(ies) granting rights
+  h. Licensor means the individual(s) or entity(ies) granting rights
      under this Public License.
 
-  k. Share means to provide material to the public by any means or
+  i. Share means to provide material to the public by any means or
      process that requires permission under the Licensed Rights, such
      as reproduction, public display, public performance, distribution,
      dissemination, communication, or importation, and to make material
@@ -74,13 +64,13 @@ Section 1 -- Definitions.
      public may access the material from a place and at a time
      individually chosen by them.
 
-  l. Sui Generis Database Rights means rights other than copyright
+  j. Sui Generis Database Rights means rights other than copyright
      resulting from Directive 96/9/EC of the European Parliament and of
      the Council of 11 March 1996 on the legal protection of databases,
      as amended and/or succeeded, as well as other essentially
      equivalent rights anywhere in the world.
 
-  m. You means the individual or entity exercising the Licensed Rights
+  k. You means the individual or entity exercising the Licensed Rights
      under this Public License. Your has a corresponding meaning.
 
 
@@ -126,13 +116,7 @@ Section 2 -- Scope.
                Licensed Rights under the terms and conditions of this
                Public License.
 
-            b. Additional offer from the Licensor -- Adapted Material.
-               Every recipient of Adapted Material from You
-               automatically receives an offer from the Licensor to
-               exercise the Licensed Rights in the Adapted Material
-               under the conditions of the Adapter's License You apply.
-
-            c. No downstream restrictions. You may not offer or impose
+            b. No downstream restrictions. You may not offer or impose
                any additional or different terms or conditions on, or
                apply any Effective Technological Measures to, the
                Licensed Material if doing so restricts exercise of the
@@ -214,24 +198,9 @@ following conditions.
           information required by Section 3(a)(1)(A) to the extent
           reasonably practicable.
 
-  b. ShareAlike.
-
-     In addition to the conditions in Section 3(a), if You Share
-     Adapted Material You produce, the following conditions also apply.
-
-       1. The Adapter's License You apply must be a Creative Commons
-          license with the same License Elements, this version or
-          later, or a BY-SA Compatible License.
-
-       2. You must include the text of, or the URI or hyperlink to, the
-          Adapter's License You apply. You may satisfy this condition
-          in any reasonable manner based on the medium, means, and
-          context in which You Share Adapted Material.
-
-       3. You may not offer or impose any additional or different terms
-          or conditions on, or apply any Effective Technological
-          Measures to, Adapted Material that restrict exercise of the
-          rights granted under the Adapter's License You apply.
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
 
 
 Section 4 -- Sui Generis Database Rights.
@@ -246,8 +215,7 @@ apply to Your use of the Licensed Material:
   b. if You include all or a substantial portion of the database
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
-     Rights (but not its individual contents) is Adapted Material,
-     including for purposes of Section 3(b); and
+     Rights (but not its individual contents) is Adapted Material; and
 
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.
@@ -349,4 +317,3 @@ Section 8 -- Interpretation.
      processes of any jurisdiction or authority.
 
 
-=======================================================================

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,7 +36,7 @@ export default defineConfig({
     ],
 
     footer: {
-      message: 'Docs released under CC-BY-SA-4.0 license. Code released under MIT license.',
+      message: 'Docs released under CC-BY-4.0 license. Code released under MIT license.',
       copyright: 'ELISA Project a Series of LF Projects, LLC'
     },
   },


### PR DESCRIPTION
Aligns the documentation license with ELISA Project policy, which standardizes on CC-BY-4.0 for project documentation. The ShareAlike requirement in CC-BY-SA-4.0 is incompatible with how ELISA member projects reuse docs across the broader ecosystem, and CC-BY-4.0 is the license called out in ELISA's contribution guidelines.

This replaces `LICENSE.CC-BY-SA-4.0` with `LICENSE.CC-BY-4.0` (full Creative Commons legal text, trimmed to match the prior body-only style) and updates the three in-tree references:

- `LICENSE` — top-level summary now points at CC-BY-4.0
- `CONTRIBUTING.md` — inbound documentation license updated
- `docs/.vitepress/config.mts` — site footer string updated

No code/recipe licensing is affected; MIT remains the license for everything under `meta-*` layers, CI, and tooling.

Because this changes the license under which prior documentation contributions were accepted, we need sign-off from everyone who has authored content under `docs/`. Tagging past contributors for explicit approval to relicense their contributions from CC-BY-SA-4.0 to CC-BY-4.0:

- @asimonov
- @csmith608
- @mattthias

Please reply on this PR with an explicit `Approved` if you're OK relicensing your prior docs contributions under CC-BY-4.0.