### PR TITLE
Add zeroconf-networking to Space Grade Linux

### DIFF
--- a/meta-sgl-core/classes/sgl-image-common.bbclass
+++ b/meta-sgl-core/classes/sgl-image-common.bbclass
@@ -1,0 +1,5 @@
+# This class defines common image features or other
+# configurations to be shared by many images
+# in meta-sgl
+
+FEATURE_PACKAGES_zeroconf-networking = "avahi-daemon avahi-utils libnss-mdns"

--- a/meta-sgl-core/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-sgl-core/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+   ${@bb.utils.contains_any('IMAGE_FEATURES', 'ssh-server-dropbear ssh-server-openssh', 'file://ssh.service', '', d)} \
+"
+
+do_install:append() {
+    if ${@bb.utils.contains_any('IMAGE_FEATURES', 'ssh-server-dropbear ssh-server-openssh', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/avahi/services
+        install -m 0644 ${WORKDIR}/ssh.service ${D}${sysconfdir}/avahi/services/
+    fi
+}

--- a/meta-sgl-core/recipes-connectivity/avahi/files/ssh.service
+++ b/meta-sgl-core/recipes-connectivity/avahi/files/ssh.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h SSH Server</name>
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+  </service>
+</service-group>

--- a/meta-sgl-core/recipes-core/systemd/systemd-conf/wired.network
+++ b/meta-sgl-core/recipes-core/systemd/systemd-conf/wired.network
@@ -1,0 +1,14 @@
+[Match]
+Type=ether
+Name=!veth*
+KernelCommandLine=!nfsroot
+KernelCommandLine=!ip
+
+[Network]
+DHCP=yes
+LinkLocalAddressing=yes
+
+[DHCP]
+UseMTU=yes
+RouteMetric=10
+ClientIdentifier=mac

--- a/meta-sgl-core/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/meta-sgl-core/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,2 @@
+# Conditionally add a new wired.network file if zeroconf-networking is enabled
+FILESEXTRAPATHS:prepend := "${@bb.utils.contains("IMAGE_FEATURES", "zeroconf-networking", "${THISDIR}/${PN}:", "",d)}"


### PR DESCRIPTION
I revised the PR submitted by Dillon for adding zero-configuration networking to Space Grade Linux.

I made sure to include Dillon as the author of the commit so that he gets credit for his work: https://github.com/elisa-tech/meta-sgl/pull/8

I removed the parts related to the kas OPTIONAL_FEATURE that was being introduced as it didn't relate directly to the zeroconf-networking IMAGE FEATURE.

I removed the kas portion that automatically inherited sgl-image-common.bbclass.  I think that bbclass should be inherited from the image recipe not from local.conf.  I didn't want a workaround to become permanent.   We should follow up and properly define the SGL image recipes (including which INIT_MANAGER they use busybox-mdev, sysvinit, or systemd)

I also removed the documentation because the zeroconf-networking instructions were not complete.

As a temporary workaround, add these lines to your conf/local.conf to enable zeroconf-networking:
```
INHERIT += "sgl-image-common"
IMAGE_FEATURES += " zeroconf-networking"
```

If using the beaglev-fire, you may write the image to your board and then plug it into the USB-C connector on your laptop.  You may then plug an Ethernet cable into the board and plug the other end into a network switch or directly into your laptop's Ethernet port.

If you are using an Ethernet cable plugged directly between your laptop and beaglev-fire, you must set up Link Local Addressing on your laptop.  On Debian 12, I disabled NetworkManager from managing the Ethernet device.  Then on the command-line I executed these commands:

```
sudo ip link set eth0 up
sudo ip addr add 169.254.1.1/16 dev eth0
```

Then I was able to run avahi-browse -at to discover Avahi services.  It reported
```
+ eth0 IPv4 beaglev-fire SSH Server                     SSH Remote Terminal  local
```

I could then use ssh to connect to the beaglev-fire:
```
ssh root@beaglev-fire.local
```
