### PR TITLE
kas: Add Space ROS Jazzy 2026.04

### DIFF
--- a/.github/workflows/test_build_beaglevfire_spaceros.yml
+++ b/.github/workflows/test_build_beaglevfire_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-beaglev-fire.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-beaglev-fire.yml
       hardware_arch: beaglev-fire
       build_profile: spaceros

--- a/.github/workflows/test_build_beaglevfire_spaceros.yml
+++ b/.github/workflows/test_build_beaglevfire_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-beaglev-fire.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-core-beaglev-fire.yml
       hardware_arch: beaglev-fire
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_arm64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_arm64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-qemuarm64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-core-qemuarm64.yml
       hardware_arch: qemuarm64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_arm64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_arm64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-qemuarm64.yml
       hardware_arch: qemuarm64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_riscv64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_riscv64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-qemuriscv64.yml
       hardware_arch: qemuriscv64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_riscv64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_riscv64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-qemuriscv64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-core-qemuriscv64.yml
       hardware_arch: qemuriscv64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_x86-64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_x86-64_spaceros.yml
@@ -1,0 +1,17 @@
+name: QEMU x86-64 + SpaceROS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-sgl.yml
+    with:
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.01-qemux86-64.yml
+      hardware_arch: qemux86-64
+      build_profile: spaceros

--- a/.github/workflows/test_build_qemu_x86-64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_x86-64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-qemux86-64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-core-qemux86-64.yml
       hardware_arch: qemux86-64
       build_profile: spaceros

--- a/.github/workflows/test_build_qemu_x86-64_spaceros.yml
+++ b/.github/workflows/test_build_qemu_x86-64_spaceros.yml
@@ -12,6 +12,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-sgl.yml
     with:
-      kas_config: sgl-scarthgap-spaceros-jazzy-2026.01-qemux86-64.yml
+      kas_config: sgl-scarthgap-spaceros-jazzy-2026.04-qemux86-64.yml
       hardware_arch: qemux86-64
       build_profile: spaceros

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-beaglev-fire.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-beaglev-fire.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-beaglev-fire.yml
     - kas/spaceros/jazzy-2025.10.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuarm64.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-qemuarm64.yml
     - kas/spaceros/jazzy-2025.10.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2025.10-qemuriscv64.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-qemuriscv64.yml
     - kas/spaceros/jazzy-2025.10.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-beaglev-fire.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-beaglev-fire.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-beaglev-fire.yml
     - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-beaglev-fire.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-beaglev-fire.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-beaglev-fire.yml
+    - kas/spaceros/jazzy-2026.04.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-beaglev-fire.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-beaglev-fire.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-beaglev-fire.yml
+    - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-core"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-qemuarm64.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuarm64.yml
+    - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-core"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-qemuriscv64.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuriscv64.yml
+    - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-core"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-qemux86-64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-core-qemux86-64.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemux86-64.yml
+    - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-core"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuarm64.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-qemuarm64.yml
     - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuarm64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuarm64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuarm64.yml
+    - kas/spaceros/jazzy-2026.04.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuriscv64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemuriscv64.yml
+    - kas/spaceros/jazzy-2026.04.yml

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuriscv64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemuriscv64.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-qemuriscv64.yml
     - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemux86-64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemux86-64.yml
@@ -3,3 +3,7 @@ header:
   includes:
     - kas/sgl-scarthgap-qemux86-64.yml
     - kas/spaceros/jazzy-2026.04.yml
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemux86-64.yml
+++ b/kas/sgl-scarthgap-spaceros-jazzy-2026.04-qemux86-64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - kas/sgl-scarthgap-qemux86-64.yml
+    - kas/spaceros/jazzy-2026.04.yml

--- a/kas/spaceros/jazzy-2025.10.yml
+++ b/kas/spaceros/jazzy-2025.10.yml
@@ -11,7 +11,3 @@ repos:
       meta-ros2:
       meta-spaceros:
       meta-spaceros-jazzy:
-
-local_conf_header:
-  spaceros: |
-    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/spaceros/jazzy-2026.04.yml
+++ b/kas/spaceros/jazzy-2026.04.yml
@@ -1,0 +1,16 @@
+header:
+  version: 14
+
+repos:
+  spaceros:
+    url: "https://github.com/ros/meta-ros.git"
+    path: "layers/meta-ros"
+    layers:
+      meta-ros-common:
+      meta-ros2:
+      meta-spaceros:
+      meta-spaceros-jazzy:
+
+local_conf_header:
+  spaceros: |
+    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/spaceros/jazzy-2026.04.yml
+++ b/kas/spaceros/jazzy-2026.04.yml
@@ -10,7 +10,3 @@ repos:
       meta-ros2:
       meta-spaceros:
       meta-spaceros-jazzy:
-
-local_conf_header:
-  spaceros: |
-    IMAGE_INSTALL:append = "packagegroup-spaceros-jazzy-world"

--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -32,3 +32,8 @@ repos:
       meta-python:
       meta-webserver:
       meta-xfce:
+
+  clang-revival:
+    branch: "main"
+    layers:
+      meta-clang-revival: "disabled"

--- a/kas/yocto/scarthgap.yml
+++ b/kas/yocto/scarthgap.yml
@@ -7,11 +7,11 @@ defaults:
   repos:
     branch: "scarthgap"
 
-# https://downloads.yoctoproject.org/releases/yocto/yocto-5.0.14/RELEASENOTES
+# https://downloads.yoctoproject.org/releases/yocto/yocto-5.0.18/RELEASENOTES
 repos:
   openembedded-core:
     url: "https://github.com/openembedded/openembedded-core.git"
-    commit: "471adaa5f77fa3b974eab60a2ded48e360042828"
+    commit: "ece80784b493c8b7493478fa2ba0dc1d6d80aa79"
     path: "layers/openembedded-core"
     layers:
       meta:
@@ -19,14 +19,14 @@ repos:
   bitbake:
     url: "https://github.com/openembedded/bitbake.git"
     branch: "2.8"
-    commit: "8dcf084522b9c66a6639b5f117f554fde9b6b45a"
+    commit: "82abbfcdbda949851a03bb2cb2049ea689564ad6"
     path: "layers/bitbake"
     layers:
       bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    commit: "2b26d30fc7f478f5735d514f0c1bc28f6a4148b6"
+    commit: "b0c2c648a1af89e7a8dd4c2ec841f3bc0ed0ccb9"
     path: "layers/meta-openembedded"
     layers:
       meta-filesystems:

--- a/kas/yocto/wrynose.yml
+++ b/kas/yocto/wrynose.yml
@@ -1,0 +1,51 @@
+header:
+  version: 14
+
+defaults:
+  repos:
+    branch: "wrynose"
+
+# https://downloads.yoctoproject.org/releases/yocto/yocto-6.0/RELEASENOTES
+repos:
+  openembedded-core:
+    url: "https://github.com/openembedded/openembedded-core.git"
+    commit: "42fa856a00ac16b2a7a83d7ecfa60a5be192b16c"
+    path: "layers/openembedded-core"
+    layers:
+      meta:
+
+  bitbake:
+    url: "https://github.com/openembedded/bitbake.git"
+    branch: "2.18"
+    commit: "33581c84f3a85008239acbd940501a35de48dc91"
+    path: "layers/bitbake"
+    layers:
+      bitbake: "disabled"
+
+  meta-yocto:
+    url: "https://git.yoctoproject.org/meta-yocto"
+    commit: "904846ae078ee20de073040ebb77c86e19250f56"
+    path: "layers/meta-yocto"
+    layers:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: "https://github.com/openembedded/meta-openembedded.git"
+    commit: "420222862f5a6d95023b8f5f3b7e1808b2264ef9"
+    path: "layers/meta-openembedded"
+    layers:
+      meta-filesystems:
+      meta-gnome:
+      meta-initramfs:
+      meta-multimedia:
+      meta-networking:
+      meta-oe:
+      meta-perl:
+      meta-python:
+      meta-webserver:
+      meta-xfce:
+
+local_conf_header:
+  distro: |
+    ERROR_QA:remove = "license-exists"


### PR DESCRIPTION
This series adds the kas configuration files to build Space ROS Jazzy 2026.04 from meta-ros.

The changes in meta-ros add recipes for Space ROS including core, moveit2, nav2, and demos.